### PR TITLE
Redirect stderr to svlogd

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,34 +1,29 @@
 ---
 driver:
-  name: docker
+  name: ec2
 
 provisioner:
-  name: chef_solo
-  require_chef_omnibus: <%= ENV['CHEF_VERSION'] %>
-  solo.rb:
-    environment: <%= ENV['AWS_ENVIRONMENT'] %>
+  name: chef_zero
+  require_chef_omnibus: 11.16.4
 
 platforms:
   - name: ubuntu-14.04
     driver:
-      image_id: <% ENV['AMI_ID' %>
+      image_id: ami-3606c456
     transport:
       username: ubuntu
   - name: centos-6.4
     driver:
       name: ec2
-      region: <%= ENV['AWS_REGION'] %>
-      aws_ssh_key_id: <%= ENV['AWS_SSH_KEY'] %>
-      instance_type: m2.xlarge
-      subnet_id: <%= ENV['SUBNET_ID'] %>
-      security_group_ids: [ <%= ENV['SECURITY_GROUP_ID'] %> ]
-      image_id: <%= ENV['METAFLOWS_AMI_ID'] %>
-      iam_profile_name: <%= ENV['IAM_ROLE'] %>
+      region: us-west-2
+      aws_ssh_key_id: shared-bootstrap
+      instance_type: m3.medium
+      image_id: ami-c5cf03a5
       tags: 
         Name: metaflows-kitchen
     transport:
       username: metaflows
-      ssh_key: <%= ENV['PATH_TO_SSH_KEY'] %>
+      ssh_key: ~/.ssh/shared-ssh-bootstrap
 
 suites:
   - name: sensor
@@ -39,4 +34,6 @@ suites:
   - name: agent
     run_list:
       - recipe[chef-metaflows::agent]
-    attributes: { sensor_ip: <%= ENV['SENSOR_IP'] %> }
+    attributes:
+      metaflows:
+        sensor_ip: 192.168.10.20

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name             'chef-metaflows'
-maintainer       'Ele Mooney'
+maintainer       'Socrata, Inc.'
 maintainer_email 'sysadmin@socrata.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-metaflows'
 long_description 'Installs/Configures chef-metaflows'
-version          '0.3.0'
+version          '0.3.1'
 
 supports 'ubuntu'
 supports 'centos'

--- a/templates/default/sv-metaflows-run.erb
+++ b/templates/default/sv-metaflows-run.erb
@@ -1,5 +1,8 @@
 #!/bin/bash
+
+exec 2>&1
+
 while true; do 
-tcpdump -s0 -i eth0 -U -n -w - 'not port 3005' | ncat -vvn --ssl <%= @options[:sensor_ip] %> 3005
-sleep 5
+  tcpdump -s0 -i eth0 -U -n -w - 'not port 3005' | ncat -vvn --ssl <%= @options[:sensor_ip] %> 3005
+  sleep 5
 done

--- a/test/integration/agent/serverspec/agent_spec.rb
+++ b/test/integration/agent/serverspec/agent_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'Metaflows agent' do
+  it 'is running metaflows' do
+    expect(service('metaflows')).to be_running
+  end
+
+  it 'redirects stderr to svlogd' do
+    file('/etc/service/metaflows/run') do
+      expect(its(:content) { should include('exec 2>&1') })
+    end
+  end
+
+end
+

--- a/test/integration/agent/serverspec/spec_helper.rb
+++ b/test/integration/agent/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec

--- a/test/integration/spec_helper.rb
+++ b/test/integration/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
Currently stderr isn't piped to svlogd, so it gets picked up by runsvdir and stuffed in the process title. This change updates the run script to redirect stderr to stdout so we can log it.
