### PR TITLE
Add a recipe for Metaflows base AMI configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0
+
+- Add a recipe for Metaflows base AMI configuration
+
 # 0.1.0
 
 Initial release of chef-metaflows

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,12 @@ maintainer_email 'sysadmin@socrata.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-metaflows'
 long_description 'Installs/Configures chef-metaflows'
-version          '0.3.2'
+version          '0.4.0'
 
 supports 'ubuntu'
 supports 'centos'
 
 depends 'runit'
+depends 'yum-chef'
+depends 'sshd'
 depends 'socrata_configuration'

--- a/recipes/sensor.rb
+++ b/recipes/sensor.rb
@@ -1,5 +1,4 @@
-# install and run the metaflows sensor/collector
-include_recipe 'runit'
+include_recipe "#{cookbook_name}::sensor_base"
 
 if node['platform'] == 'centos'
   package 'expect'

--- a/recipes/sensor_base.rb
+++ b/recipes/sensor_base.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+# frozen_string_literal: true
+#
+# Cookbook Name:: chef-metaflows
+# Recipe:: sensor_base
+#
+
+# Perform the initial operations needed to build a Metaflows image.
+
+%w(
+  yum-chef
+  sshd
+  runit
+).each do |r|
+  include_recipe r
+end
+
+package 'cloud-init'


### PR DESCRIPTION
The image we build Metaflows from doesn't come with cloud-init
installed, so we need a recipe somewhere that'll handle it and
socrata-aws-base-ami is a decent way from being compatible with CentOS.